### PR TITLE
Fix treasure deck update

### DIFF
--- a/src/Util/Treasure.Util.js
+++ b/src/Util/Treasure.Util.js
@@ -6,13 +6,13 @@ const updateDeck = TreasureStore.getState().updateDeck;
 class TreasureUtil {
     static getRandomTreasure = () => {
         let _treasureDeck = treasureDeck;
-        let randomTreasure = {};
         if (_treasureDeck.length > 0) {
             const randomIndex = Math.floor(Math.random() * _treasureDeck.length);
-            randomTreasure = _treasureDeck[randomIndex];
-            updateDeck(_treasureDeck.splice(randomIndex, 1));
+            const removed = _treasureDeck.splice(randomIndex, 1)[0];
+            updateDeck([..._treasureDeck]);
+            return removed;
         }
-        return randomTreasure;
+        return {};
     };
 }
 

--- a/src/Util/Treasure.Util.test.js
+++ b/src/Util/Treasure.Util.test.js
@@ -1,0 +1,17 @@
+import TreasureStore from '../Store/Treasure.store';
+import treasureDeck from '../Assets/Treasure';
+
+describe('getRandomTreasure', () => {
+  beforeEach(() => {
+    TreasureStore.getState().updateDeck([...treasureDeck]);
+    jest.resetModules();
+  });
+
+  test('removes one item from the deck', () => {
+    const TreasureUtil = require('./Treasure.Util').default;
+    const initialLength = TreasureStore.getState().deck.length;
+    TreasureUtil.getRandomTreasure();
+    const finalLength = TreasureStore.getState().deck.length;
+    expect(finalLength).toBe(initialLength - 1);
+  });
+});


### PR DESCRIPTION
## Summary
- update treasure util to persist deck changes
- add a unit test for deck shrinkage after pulling treasure

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c658228c83269c5427ce47c6d7b6