### PR TITLE
Add game reset button and helper

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -343,6 +343,16 @@ body {
   left: 70px;
 }
 
+.controller-container .reset-button {
+  top: 95px;
+  left: 25px;
+  width: 60px;
+  height: 25px;
+  border-radius: 5px;
+  background: none;
+  position: absolute;
+}
+
 // Modal
 .fade.modal-backdrop.show {
   opacity: 0.6;

--- a/src/Components/Controller.component.js
+++ b/src/Components/Controller.component.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { resetGame } from '../Util/Storage.Util';
 import VikingStore from '../Store/Viking.store';
 import roomStore from '../Store/Room.store';
 
@@ -68,12 +69,19 @@ function ControllerComponent() {
         moveVikingLeft();
     }
 
+    const handleResetGame = () => {
+        if (window.confirm('Reset the game? This will clear all progress.')) {
+            resetGame();
+        }
+    }
+
     return (
         <div className='controller-container'>
             <button className='top' disabled={!upButtonState} onClick={() => { moveUp() }}></button>
             <button className='right' disabled={!rightButtonState} onClick={() => { moveRight() }}></button>
             <button className='bottom' disabled={!bottomButtonState} onClick={() => { moveBottom() }}></button>
             <button className='left' disabled={!leftButtonState} onClick={() => { moveLeft() }}></button>
+            <button className='reset-button' onClick={handleResetGame}>Reset</button>
         </div >
     )
 }

--- a/src/Store/Dice.store.js
+++ b/src/Store/Dice.store.js
@@ -22,7 +22,14 @@ const DiceStore = create((set) => ({
     resetDiceScore: () => set(() => ({ diceScore: defaultDiceScore })),
     confirmDiceScore: () => set(() => ({ isConfirm: true })),
     clearConfirmState: () => set(() => ({ isConfirm: false })),
-    setDicePhase: (phase) => set(() => ({ dicePhase: phase }))
+    setDicePhase: (phase) => set(() => ({ dicePhase: phase })),
+    resetAll: () => set(() => ({
+        isShowPopup: false,
+        diceScore: defaultDiceScore,
+        isConfirm: false,
+        dicePhase: 'INITIAL',
+        isShaking: false
+    }))
 }));
 
 export default DiceStore;

--- a/src/Store/Goblin.store.js
+++ b/src/Store/Goblin.store.js
@@ -20,6 +20,7 @@ const GoblinStore = create((set) => ({
     moveLeft: (index) => set((state) => ({
         gang: state.gang.map((goblin, i) => i === index ? { ...goblin, position: { x: goblin.position.x - 1, y: goblin.position.y } } : goblin)
     })),
+    resetAll: () => set(() => ({ gang: [] }))
 }));
 
 export default GoblinStore;

--- a/src/Store/LootPopup.store.js
+++ b/src/Store/LootPopup.store.js
@@ -11,6 +11,12 @@ const LootPopupStore = create((set) => ({
     isEnd: false,
     begin: (isBegin) => set(() => ({ isBegin: true, isEnd: false })),
     end: (isEnd) => set(() => ({ isBegin: false, isEnd: true })),
+    resetAll: () => set(() => ({
+        isShowPopup: false,
+        newFoundLoot: {},
+        isBegin: false,
+        isEnd: false
+    }))
 }));
 
 export default LootPopupStore;

--- a/src/Store/Room.store.js
+++ b/src/Store/Room.store.js
@@ -84,6 +84,7 @@ const roomStore = create((set) => ({
       }
     }
   })),
+  resetAll: () => set(() => ({ rooms: initialRoomData }))
 }));
 
 export default roomStore;

--- a/src/Store/Treasure.store.js
+++ b/src/Store/Treasure.store.js
@@ -4,6 +4,7 @@ import tresureDeck from '../Assets/Treasure';
 const TreasureStore = create((set) => ({
     deck: tresureDeck,
     updateDeck: (newDeckData) => set(() => ({ deck: newDeckData })),
+    resetAll: () => set(() => ({ deck: tresureDeck }))
 }))
 
 export default TreasureStore;

--- a/src/Store/Viking.store.js
+++ b/src/Store/Viking.store.js
@@ -76,6 +76,24 @@ const VikingStore = create((set, get) => ({
             max: state.health.max
         }
     })),
+    resetAll: () => set(() => ({
+        name: "Bjorn the Brave",
+        class: "Viking Warrior",
+        defend: 5,
+        dicePower: { attack: 3, magic: 1, speed: 2 },
+        health: { current: 10, max: 10 },
+        action: { current: 5, max: 5 },
+        move: { current: 6, max: 6 },
+        position: [3, 3],
+        previousPosition: [3, 3],
+        comeFromPath: '',
+        offset: [0, 0],
+        weapon: [VikingAxe],
+        armor: [],
+        rune: [],
+        spell: [],
+        isMoveDone: true
+    }))
 }));
 
 export default VikingStore;

--- a/src/Store/WinRewards.store.js
+++ b/src/Store/WinRewards.store.js
@@ -3,6 +3,7 @@ import { create } from 'zustand'
 const WinRewardsStore = create((set, get) => ({
     rewards: [],
     setRewards: (rewards) => set(() => ({ rewards: rewards })),
+    resetAll: () => set(() => ({ rewards: [] }))
 }))
 
 export default WinRewardsStore;

--- a/src/Util/Storage.Util.js
+++ b/src/Util/Storage.Util.js
@@ -1,0 +1,26 @@
+export const clearLocalStorage = () => {
+    if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.clear();
+    }
+};
+
+import DiceStore from '../Store/Dice.store';
+import GameStateStore from '../Store/GameState.store';
+import GoblinStore from '../Store/Goblin.store';
+import LootPopupStore from '../Store/LootPopup.store';
+import roomStore from '../Store/Room.store';
+import TreasureStore from '../Store/Treasure.store';
+import VikingStore from '../Store/Viking.store';
+import WinRewardsStore from '../Store/WinRewards.store';
+
+export const resetGame = () => {
+    clearLocalStorage();
+    DiceStore.getState().resetAll && DiceStore.getState().resetAll();
+    GameStateStore.getState().resetAll && GameStateStore.getState().resetAll();
+    GoblinStore.getState().resetAll && GoblinStore.getState().resetAll();
+    LootPopupStore.getState().resetAll && LootPopupStore.getState().resetAll();
+    roomStore.getState().resetAll && roomStore.getState().resetAll();
+    TreasureStore.getState().resetAll && TreasureStore.getState().resetAll();
+    VikingStore.getState().resetAll && VikingStore.getState().resetAll();
+    WinRewardsStore.getState().resetAll && WinRewardsStore.getState().resetAll();
+};


### PR DESCRIPTION
## Summary
- provide a global resetGame helper that clears localStorage and resets all stores
- add `resetAll` actions for each Zustand store
- add Reset button to Controller component
- style the new reset button

## Testing
- `npm install`
- `npm test --silent` *(fails: Unable to find element with the text /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_6844f27873a883268946e3843f4208b2