### PR TITLE
Add prop type definitions

### DIFF
--- a/src/Components/Controller.component.js
+++ b/src/Components/Controller.component.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import VikingStore from '../Store/Viking.store';
 import roomStore from '../Store/Room.store';
 
@@ -77,5 +78,7 @@ function ControllerComponent() {
         </div >
     )
 }
+
+ControllerComponent.propTypes = {};
 
 export default ControllerComponent;

--- a/src/Components/DiceItem.component.js
+++ b/src/Components/DiceItem.component.js
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import PropTypes from 'prop-types';
 import _ from "lodash";
 import "./DiceItem.scss";
 
@@ -32,4 +33,20 @@ export const DiceItem = ({ isShaking, diceOrder, diceFace, totalDiceScore, selec
                 <div className={`dice-item ${isShaking ? 'shaking-' : ''}${diceOrder}`}></div>}
         </>
     );
+};
+
+DiceItem.propTypes = {
+    isShaking: PropTypes.bool,
+    diceOrder: PropTypes.number,
+    diceFace: PropTypes.object,
+    totalDiceScore: PropTypes.number,
+    selectDice: PropTypes.func,
+};
+
+DiceItem.defaultProps = {
+    isShaking: false,
+    diceOrder: 0,
+    diceFace: null,
+    totalDiceScore: 0,
+    selectDice: () => { },
 };

--- a/src/Components/Goblin/FightContainerComponent.js
+++ b/src/Components/Goblin/FightContainerComponent.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 import GoblinStore from '../../Store/Goblin.store';
 import _ from 'lodash';
 import { Button } from 'react-bootstrap';
@@ -190,4 +191,14 @@ export default function FightContainerComponent({ weapon, setWeaponToAttack, gob
         </div>;
     }
 
+};
+
+FightContainerComponent.propTypes = {
+    weapon: PropTypes.object,
+    setWeaponToAttack: PropTypes.func.isRequired,
+    goblinIndex: PropTypes.number.isRequired,
+};
+
+FightContainerComponent.defaultProps = {
+    weapon: null,
 };

--- a/src/Components/Goblin/Goblin.component.js
+++ b/src/Components/Goblin/Goblin.component.js
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useState } from "react";
+import PropTypes from 'prop-types';
 import roomStore from "../../Store/Room.store";
 import "./Goblin.scss";
 // import { GoblinDetailComponent } from "./GoblinDetail.component";
@@ -30,3 +31,8 @@ function GoblinComponent({ index, goblin }) {
         </div >
     );
 }
+
+GoblinComponent.propTypes = {
+    index: PropTypes.number.isRequired,
+    goblin: PropTypes.object.isRequired,
+};

--- a/src/Components/Goblin/GoblinCard.component.js
+++ b/src/Components/Goblin/GoblinCard.component.js
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import PropTypes from 'prop-types';
 import DiceStore from "../../Store/Dice.store";
 import GameStateStore, { FightPhaseEnum } from "../../Store/GameState.store";
 import { MonsterDiceComponent } from "./MonsterDiceComponent";
@@ -149,3 +150,7 @@ export default function GoblinCardComponent({ goblin }) {
         // </div>
     );
 }
+
+GoblinCardComponent.propTypes = {
+    goblin: PropTypes.object.isRequired,
+};

--- a/src/Components/Goblin/GoblinEncounter.component.js
+++ b/src/Components/Goblin/GoblinEncounter.component.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 import Modal from 'react-bootstrap/Modal';
 import GoblinStore from '../../Store/Goblin.store';
 import _ from 'lodash';
@@ -19,6 +20,15 @@ const CardPlaceholderComponent = ({ size, className }) => {
             <div className='corner bottom-right'></div>
         </div>
     );
+};
+
+CardPlaceholderComponent.propTypes = {
+    size: PropTypes.string.isRequired,
+    className: PropTypes.string,
+};
+
+CardPlaceholderComponent.defaultProps = {
+    className: '',
 };
 
 export default GoblinEncounterComponent;
@@ -112,5 +122,9 @@ function GoblinEncounterComponent({ index }) {
     }
 
 }
+
+GoblinEncounterComponent.propTypes = {
+    index: PropTypes.number.isRequired,
+};
 
 

--- a/src/Components/Goblin/MonsterDiceComponent.js
+++ b/src/Components/Goblin/MonsterDiceComponent.js
@@ -1,3 +1,13 @@
+import PropTypes from 'prop-types';
+
 export const MonsterDiceComponent = ({ isDiceShaking }) => {
     return <div className={`dice-item monster-dice-container` + `${isDiceShaking ? ' shaking' : ''}`}></div>;
+};
+
+MonsterDiceComponent.propTypes = {
+    isDiceShaking: PropTypes.bool,
+};
+
+MonsterDiceComponent.defaultProps = {
+    isDiceShaking: false,
 };

--- a/src/Components/HeroAction.component.js
+++ b/src/Components/HeroAction.component.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import PropTypes from 'prop-types';
 import _, { set } from "lodash";
 import roomStore from "../Store/Room.store";
 import VikingStore from "../Store/Viking.store";
@@ -200,6 +201,8 @@ function HeroActionComponent() {
     );
 }
 
+HeroActionComponent.propTypes = {};
+
 const DiceActionButton = ({ diceOrder, dice, totalDiceScore, selectDice }) => {
     if (!_.isUndefined(dice) && !dice.selected) {
         if (totalDiceScore === 0) {
@@ -212,6 +215,20 @@ const DiceActionButton = ({ diceOrder, dice, totalDiceScore, selectDice }) => {
     } else {
         return <div />;
     }
+};
+
+DiceActionButton.propTypes = {
+    diceOrder: PropTypes.number,
+    dice: PropTypes.object,
+    totalDiceScore: PropTypes.number,
+    selectDice: PropTypes.func,
+};
+
+DiceActionButton.defaultProps = {
+    diceOrder: 0,
+    dice: null,
+    totalDiceScore: 0,
+    selectDice: () => { },
 };
 
 export default HeroActionComponent;

--- a/src/Components/HeroDisplay.component.js
+++ b/src/Components/HeroDisplay.component.js
@@ -1,4 +1,5 @@
 import VikingStore from "../Store/Viking.store";
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { Tooltip } from 'react-tooltip';
 
@@ -29,6 +30,18 @@ function ItemDisplay({ item, tooltipId, emptyClassName, itemType }) {
         </>
     );
 }
+
+ItemDisplay.propTypes = {
+    item: PropTypes.object,
+    tooltipId: PropTypes.string.isRequired,
+    emptyClassName: PropTypes.string.isRequired,
+    itemType: PropTypes.string,
+};
+
+ItemDisplay.defaultProps = {
+    item: null,
+    itemType: 'equipment',
+};
 
 function HeroDisplayComponent() {
     const vikingData = VikingStore((state) => state);
@@ -105,5 +118,7 @@ function HeroDisplayComponent() {
         </div>
     );
 }
+
+HeroDisplayComponent.propTypes = {};
 
 export default HeroDisplayComponent;

--- a/src/Components/ItemCard.component.js
+++ b/src/Components/ItemCard.component.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const ItemCard = ({ itemDetail, setRemoveIndex, removeIndex, weaponIndex, needToDiscard }) => {
     const { name, description, attack, defend, effect, rarity, id, type } = itemDetail;
@@ -32,6 +33,21 @@ const ItemCard = ({ itemDetail, setRemoveIndex, removeIndex, weaponIndex, needTo
             {(removeIndex === weaponIndex) && <div className="discard-mark"></div>}
         </div>
     );
+};
+
+ItemCard.propTypes = {
+    itemDetail: PropTypes.object.isRequired,
+    setRemoveIndex: PropTypes.func,
+    removeIndex: PropTypes.number,
+    weaponIndex: PropTypes.number,
+    needToDiscard: PropTypes.bool,
+};
+
+ItemCard.defaultProps = {
+    setRemoveIndex: () => { },
+    removeIndex: null,
+    weaponIndex: null,
+    needToDiscard: false,
 };
 
 export default ItemCard;

--- a/src/Components/LootPopup.component.js
+++ b/src/Components/LootPopup.component.js
@@ -2,6 +2,7 @@ import ItemCard from './ItemCard.component';
 import VikingStore from '../Store/Viking.store';
 import roomStore from '../Store/Room.store';
 import { useState } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Modal from 'react-bootstrap/Modal';
 import LootPopupStore from './../Store/LootPopup.store';
@@ -107,5 +108,7 @@ function LootPopup() {
         </Modal>
     );
 }
+
+LootPopup.propTypes = {};
 
 export default LootPopup;

--- a/src/Components/Room/Room.component.js
+++ b/src/Components/Room/Room.component.js
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import roomStore from '../../Store/Room.store';
 import VikingStore from '../../Store/Viking.store';
 import RoomPaths from './RoomPaths.component';
@@ -189,5 +190,11 @@ function RoomComponent({ roomNumber, isRoomRotating, setIsRoomRotating }) {
     return roomStatus === 'revealed' || isOperatingRoom || isEntranceRoom;
   }
 }
+
+RoomComponent.propTypes = {
+  roomNumber: PropTypes.arrayOf(PropTypes.number).isRequired,
+  isRoomRotating: PropTypes.bool.isRequired,
+  setIsRoomRotating: PropTypes.func.isRequired,
+};
 
 export default RoomComponent;

--- a/src/Components/Room/RoomPaths.component.js
+++ b/src/Components/Room/RoomPaths.component.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { oppositeDirection } from '../../Util/Room.Util';
 
 const RoomPaths = ({ roomData, comeFromPath, isShowPreviousPath }) => {
@@ -10,6 +11,16 @@ const RoomPaths = ({ roomData, comeFromPath, isShowPreviousPath }) => {
             </div>
         )
     ));
+};
+
+RoomPaths.propTypes = {
+    roomData: PropTypes.object.isRequired,
+    comeFromPath: PropTypes.string,
+    isShowPreviousPath: PropTypes.func.isRequired,
+};
+
+RoomPaths.defaultProps = {
+    comeFromPath: '',
 };
 
 export default RoomPaths;

--- a/src/Components/Room/RotateButton.component.js
+++ b/src/Components/Room/RotateButton.component.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const RotateButtons = ({ confirmButtonState, rotateRoomExit, confirmRoom }) => (
     <div className='button-container'>
@@ -6,5 +7,11 @@ const RotateButtons = ({ confirmButtonState, rotateRoomExit, confirmRoom }) => (
         <button className='confirm-rotate-button' disabled={!confirmButtonState} onClick={confirmRoom}></button>
     </div>
 );
+
+RotateButtons.propTypes = {
+    confirmButtonState: PropTypes.bool.isRequired,
+    rotateRoomExit: PropTypes.func.isRequired,
+    confirmRoom: PropTypes.func.isRequired,
+};
 
 export default RotateButtons;

--- a/src/Components/RoomDisplay.component.js
+++ b/src/Components/RoomDisplay.component.js
@@ -1,5 +1,6 @@
 import roomStore from '../Store/Room.store';
 import VikingStore from '../Store/Viking.store';
+import PropTypes from 'prop-types';
 import './RoomDisplay.scss';
 
 function RoomDisplayComponent({ diceScore }) {
@@ -31,5 +32,13 @@ function RoomDisplayComponent({ diceScore }) {
         </div>
     );
 }
+
+RoomDisplayComponent.propTypes = {
+    diceScore: PropTypes.number,
+};
+
+RoomDisplayComponent.defaultProps = {
+    diceScore: 0,
+};
 
 export default RoomDisplayComponent;

--- a/src/Components/Viking.component.js
+++ b/src/Components/Viking.component.js
@@ -1,4 +1,5 @@
 import VikingStore from '../Store/Viking.store';
+import PropTypes from 'prop-types';
 
 function VikingComponent() {
     const vikingOffset = VikingStore((state) => state.offset);
@@ -10,5 +11,7 @@ function VikingComponent() {
         </>
     )
 }
+
+VikingComponent.propTypes = {};
 
 export default VikingComponent;

--- a/src/Components/WinRewards.component.js
+++ b/src/Components/WinRewards.component.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import PropTypes from 'prop-types';
 import WinRewardsStore from "../Store/WinRewards.store";
 import _ from "lodash";
 import './WinRewards.scss'
@@ -77,3 +78,5 @@ export default function WinRewardsComponent() {
     //     }
     // }
 }
+
+WinRewardsComponent.propTypes = {};


### PR DESCRIPTION
## Summary
- add PropTypes definitions across component files
- supply default props where appropriate

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f274c43883268d425431475f66a4