### PR TITLE
Remove unused clear import

### DIFF
--- a/src/Store/Dice.store.js
+++ b/src/Store/Dice.store.js
@@ -1,4 +1,3 @@
-import { clear } from '@testing-library/user-event/dist/clear';
 import { create } from 'zustand';
 
 const defaultDiceScore = {


### PR DESCRIPTION
## Summary
- delete unused `clear` import from `Dice.store`

## Testing
- `npm test -- --watchAll=false` *(fails: TestingLibraryElementError)*

------
https://chatgpt.com/codex/tasks/task_e_6844f270858083268712febd44b9b437