### PR TITLE
Implement basic game persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ You may also see any lint errors in the console.
 Launches the test runner in the interactive watch mode.\
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
 
+## Game State Persistence
+
+The application automatically saves your progress to **localStorage**. When the
+app loads it restores the last saved state for all the Zustand stores, including
+rooms, the hero data and ongoing battles. Any change in the stores triggers a
+save so closing your browser will not lose progress. You can clear the persisted
+data by calling the exported `resetGameState` helper in `Storage.Util.js`.
+
 ### `npm run build`
 
 Builds the app for production to the `build` folder.\

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app container', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const appElement = document.querySelector('.App');
+  expect(appElement).toBeInTheDocument();
 });

--- a/src/Util/Storage.Util.js
+++ b/src/Util/Storage.Util.js
@@ -1,0 +1,117 @@
+const STORAGE_KEY = 'dungeon-game-state';
+
+import VikingStore from '../Store/Viking.store';
+import roomStore from '../Store/Room.store';
+import GoblinStore from '../Store/Goblin.store';
+import DiceStore from '../Store/Dice.store';
+import GameStateStore from '../Store/GameState.store';
+import TreasureStore from '../Store/Treasure.store';
+import WinRewardsStore from '../Store/WinRewards.store';
+import LootPopupStore from '../Store/LootPopup.store';
+
+// Capture initial states so we can reset stores later
+const initialViking = VikingStore.getState();
+const initialRooms = roomStore.getState();
+const initialGoblins = GoblinStore.getState();
+const initialDice = DiceStore.getState();
+const initialGame = GameStateStore.getState();
+const initialTreasure = TreasureStore.getState();
+const initialRewards = WinRewardsStore.getState();
+const initialLootPopup = LootPopupStore.getState();
+
+const extractViking = (state) => ({
+    name: state.name,
+    class: state.class,
+    defend: state.defend,
+    dicePower: state.dicePower,
+    health: state.health,
+    action: state.action,
+    move: state.move,
+    position: state.position,
+    previousPosition: state.previousPosition,
+    comeFromPath: state.comeFromPath,
+    offset: state.offset,
+    weapon: state.weapon,
+    armor: state.armor,
+    rune: state.rune,
+    spell: state.spell,
+    isMoveDone: state.isMoveDone,
+});
+
+const extractDice = (state) => ({
+    isShowPopup: state.isShowPopup,
+    diceScore: state.diceScore,
+    isConfirm: state.isConfirm,
+    dicePhase: state.dicePhase,
+    isShaking: state.isShaking,
+});
+
+const extractGame = (state) => ({
+    fightPhase: state.fightPhase,
+    netAttackValue: state.netAttackValue,
+    monsterShieldBroken: state.monsterShieldBroken,
+    monsterHeartBroken: state.monsterHeartBroken,
+});
+
+const extractLootPopup = (state) => ({
+    isShowPopup: state.isShowPopup,
+    newFoundLoot: state.newFoundLoot,
+    isBegin: state.isBegin,
+    isEnd: state.isEnd,
+});
+
+export const saveGameState = () => {
+    const state = {
+        viking: extractViking(VikingStore.getState()),
+        rooms: roomStore.getState().rooms,
+        goblins: GoblinStore.getState().gang,
+        dice: extractDice(DiceStore.getState()),
+        game: extractGame(GameStateStore.getState()),
+        treasure: TreasureStore.getState().deck,
+        rewards: WinRewardsStore.getState().rewards,
+        lootPopup: extractLootPopup(LootPopupStore.getState()),
+    };
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (e) {
+        console.error('Failed to save game state', e);
+    }
+};
+
+export const loadGameState = () => {
+    try {
+        const value = localStorage.getItem(STORAGE_KEY);
+        return value ? JSON.parse(value) : null;
+    } catch (e) {
+        console.error('Failed to load game state', e);
+        return null;
+    }
+};
+
+export const applyGameState = (state) => {
+    if (!state) return;
+    if (state.viking) VikingStore.setState((s) => ({ ...s, ...state.viking }));
+    if (state.rooms) roomStore.setState((s) => ({ ...s, rooms: state.rooms }));
+    if (state.goblins) GoblinStore.setState((s) => ({ ...s, gang: state.goblins }));
+    if (state.dice) DiceStore.setState((s) => ({ ...s, ...state.dice }));
+    if (state.game) GameStateStore.setState((s) => ({ ...s, ...state.game }));
+    if (state.treasure) TreasureStore.setState((s) => ({ ...s, deck: state.treasure }));
+    if (state.rewards) WinRewardsStore.setState((s) => ({ ...s, rewards: state.rewards }));
+    if (state.lootPopup) LootPopupStore.setState((s) => ({ ...s, ...state.lootPopup }));
+};
+
+export const resetStores = () => {
+    VikingStore.setState(initialViking, true);
+    roomStore.setState(initialRooms, true);
+    GoblinStore.setState(initialGoblins, true);
+    DiceStore.setState(initialDice, true);
+    GameStateStore.setState(initialGame, true);
+    TreasureStore.setState(initialTreasure, true);
+    WinRewardsStore.setState(initialRewards, true);
+    LootPopupStore.setState(initialLootPopup, true);
+};
+
+export const resetGameState = () => {
+    localStorage.removeItem(STORAGE_KEY);
+    resetStores();
+};

--- a/src/__tests__/persistence.test.js
+++ b/src/__tests__/persistence.test.js
@@ -1,0 +1,25 @@
+import { saveGameState, loadGameState, applyGameState, resetGameState, resetStores } from '../Util/Storage.Util';
+import VikingStore from '../Store/Viking.store';
+import roomStore from '../Store/Room.store';
+
+beforeEach(() => {
+  resetGameState();
+});
+
+test('restores saved viking and room state', () => {
+  VikingStore.setState((s) => ({ ...s, position: [1, 1], health: { current: 5, max: 10 } }));
+  roomStore.getState().assignRoom(1, 1, { id: 42 });
+
+  saveGameState();
+
+  resetStores();
+
+  expect(VikingStore.getState().position).toEqual([3, 3]);
+
+  const saved = loadGameState();
+  applyGameState(saved);
+
+  expect(VikingStore.getState().position).toEqual([1, 1]);
+  expect(VikingStore.getState().health.current).toBe(5);
+  expect(roomStore.getState().rooms[1][1].id).toBe(42);
+});

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,35 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import {
+  loadGameState,
+  applyGameState,
+  saveGameState
+} from './Util/Storage.Util';
+import VikingStore from './Store/Viking.store';
+import roomStore from './Store/Room.store';
+import GoblinStore from './Store/Goblin.store';
+import DiceStore from './Store/Dice.store';
+import GameStateStore from './Store/GameState.store';
+import TreasureStore from './Store/Treasure.store';
+import WinRewardsStore from './Store/WinRewards.store';
+import LootPopupStore from './Store/LootPopup.store';
+
+const savedState = loadGameState();
+if (savedState) {
+  applyGameState(savedState);
+}
+
+[
+  VikingStore,
+  roomStore,
+  GoblinStore,
+  DiceStore,
+  GameStateStore,
+  TreasureStore,
+  WinRewardsStore,
+  LootPopupStore
+].forEach((store) => store.subscribe(saveGameState));
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## Summary
- add utility for saving/loading/resetting game state to localStorage
- load stored state and subscribe to state changes on startup
- document persistence behaviour
- clean up CRA sample test and add persistence unit test

## Testing
- `CI=true npm test -- --runTestsByPath src/App.test.js src/__tests__/persistence.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6844f2639a288326aff97673ff72dcde