### PR TITLE
Implement goblin counterattack

### DIFF
--- a/src/Components/Goblin/FightContainerComponent.js
+++ b/src/Components/Goblin/FightContainerComponent.js
@@ -29,6 +29,7 @@ export default function FightContainerComponent({ weapon, setWeaponToAttack, gob
     const [rollResult, setRollResult] = useState([0, 0, 0]);
     const [effectHeroGet, setEffectHeroGet] = useState({ action: 0, health: 0 });
     const [isConfirmDice, setIsConfirmDice] = useState(false);
+    const [monsterDiceResult, setMonsterDiceResult] = useState(0);
 
     const selectDice = (diceOrder, score) => {
         rollResult[diceOrder].selected = true;
@@ -126,6 +127,10 @@ export default function FightContainerComponent({ weapon, setWeaponToAttack, gob
                 setTimeout(() => {
                     gameState.setAttackHealth();
                 }, 1000);
+            } else {
+                setTimeout(() => {
+                    gameState.setCounterAttack();
+                }, 1000);
             }
         }
 
@@ -154,13 +159,19 @@ export default function FightContainerComponent({ weapon, setWeaponToAttack, gob
         }
 
         if (gameState.fightPhase === FightPhaseEnum.COUNTER_ATTACK) {
-            VikingStore.getState().takeDamage(goblin.counterAttack.damage);
+            const dice = DiceUtil.rollDice();
+            setMonsterDiceResult(dice.number);
+            gameState.setCounterAttackDice(dice.number);
+            const bonus = goblin.counterAttack.bonusPerGoblin ? goblin.counterAttack.bonusPerGoblin * (goblinStore.gang.length - 1) : 0;
+            const damage = dice.number + goblin.counterAttack.damage + bonus;
+            VikingStore.getState().takeDamage(damage);
             setTimeout(() => {
                 gameState.setCounterAttackEnd();
             }, 1000);
         }
 
         if (gameState.fightPhase === FightPhaseEnum.COUNTER_ATTACK_END) {
+            setMonsterDiceResult(0);
             gameState.resetAll();
         }
 

--- a/src/Components/Goblin/FightContainerComponent.js
+++ b/src/Components/Goblin/FightContainerComponent.js
@@ -142,10 +142,26 @@ export default function FightContainerComponent({ weapon, setWeaponToAttack, gob
                     gameState.setMonsterDie();
                 }, 1000);
             }
+            else {
+                setTimeout(() => {
+                    gameState.setCounterAttack();
+                }, 1000);
+            }
         }
 
         if (gameState.fightPhase === FightPhaseEnum.MONSTER_DIE) {
             winRewards.setStart();
+        }
+
+        if (gameState.fightPhase === FightPhaseEnum.COUNTER_ATTACK) {
+            VikingStore.getState().takeDamage(goblin.counterAttack.damage);
+            setTimeout(() => {
+                gameState.setCounterAttackEnd();
+            }, 1000);
+        }
+
+        if (gameState.fightPhase === FightPhaseEnum.COUNTER_ATTACK_END) {
+            gameState.resetAll();
         }
 
         if (winRewards.state === WinRewardsStaeENUM.START) {

--- a/src/Components/Goblin/Goblin.scss
+++ b/src/Components/Goblin/Goblin.scss
@@ -756,6 +756,12 @@
         width: 100%;
         height: 25%;
     }
+
+    .ack-button {
+        margin-left: 10px;
+        font-size: 1rem;
+        padding: 0 5px;
+    }
 }
 
 .dice-item,

--- a/src/Components/Goblin/Goblin.scss
+++ b/src/Components/Goblin/Goblin.scss
@@ -1,3 +1,15 @@
+@keyframes panel-shake {
+    0% { transform: rotate(0deg); }
+    25% { transform: rotate(4deg); }
+    50% { transform: rotate(0deg); }
+    75% { transform: rotate(-6deg); }
+    100% { transform: rotate(0deg); }
+}
+
+.action-panel.shaking {
+    animation: panel-shake 0.18s ease-in-out 0s 2;
+}
+
 .avatar-goblin {
     position: absolute;
     width: 30px;

--- a/src/Components/Goblin/Goblin.scss
+++ b/src/Components/Goblin/Goblin.scss
@@ -871,6 +871,14 @@
     right: 10px;
     height: 15%;
     width: auto;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    .dice-number {
+        color: #fff;
+        font-size: 50cqw;
+    }
 
     &.hero-phase {
         visibility: hidden;

--- a/src/Components/Goblin/GoblinCard.component.js
+++ b/src/Components/Goblin/GoblinCard.component.js
@@ -33,7 +33,11 @@ export default function GoblinCardComponent({ goblin }) {
                     {goblin.attack.range === 0 && <i className="icon-badge icon-in-detail same-location-icon" />}
                     <i className="icon-in-detail icon-skill icon-windwalk" />
                 </div>
-                {gameState.fightPhase.number === 1 && <MonsterDiceComponent isDiceShaking={diceStore.isShaking} />}
+                {(gameState.fightPhase.number === 1 || gameState.fightPhase === FightPhaseEnum.COUNTER_ATTACK) &&
+                    <MonsterDiceComponent
+                        isDiceShaking={diceStore.isShaking}
+                        diceNumber={gameState.fightPhase === FightPhaseEnum.COUNTER_ATTACK ? gameState.counterAttackDice : undefined}
+                    />}
                 <div className="card-row top-row">
                     <i className="icon-counter-attack icon-in-detail icon-badge" />
                     {goblin.counterAttack.damage > 0 ? <>

--- a/src/Components/Goblin/MonsterDiceComponent.js
+++ b/src/Components/Goblin/MonsterDiceComponent.js
@@ -1,4 +1,8 @@
-export const MonsterDiceComponent = ({ isDiceShaking }) => {
-    return <div className={`dice-item monster-dice-container` + `${isDiceShaking ? ' shaking' : ''}`}></div>;
+export const MonsterDiceComponent = ({ isDiceShaking, diceNumber }) => {
+    return (
+        <div className={`dice-item monster-dice-container${isDiceShaking ? ' shaking' : ''}`}> 
+            {diceNumber !== undefined && <span className="dice-number">{diceNumber}</span>}
+        </div>
+    );
 };
 

--- a/src/Store/GameState.store.js
+++ b/src/Store/GameState.store.js
@@ -46,11 +46,14 @@ const GameStoteStore = create((set) => ({
     setMonsterShieldBroken: (value) => set(() => ({ monsterShieldBroken: value })),
     monsterHeartBroken: false,
     setMonsterHeartBroken: (value) => set(() => ({ monsterHeartBroken: value })),
+    counterAttackDice: 0,
+    setCounterAttackDice: (value) => set(() => ({ counterAttackDice: value })),
     resetAll: () => set(() => ({
         fightPhase: FightPhaseEnum.IDLE,
         netAttackValue: 0,
         monsterShieldBroken: false,
         monsterHeartBroken: false,
+        counterAttackDice: 0,
         goblinEncounter: false
     }))
 }));


### PR DESCRIPTION
## Summary
- handle hero failure to kill goblin
- apply counterattack damage and reset encounter

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68464ed09b6483268ccc1fe1daf03565